### PR TITLE
🐛 Fix `Trifolium.Config.token/0` docs

### DIFF
--- a/lib/trifolium/config.ex
+++ b/lib/trifolium/config.ex
@@ -8,7 +8,7 @@ defmodule Trifolium.Config do
 
   @doc """
   Returns Trefle's API token. Set it in `mix.exs`:
-      config :trifolium, trefle_token: "YOUR_TREFLE_TOKEN"
+      config :trifolium, token: "YOUR_TREFLE_TOKEN"
   """
   @spec token :: String.t()
   def token, do: from_env(:trifolium, :token)


### PR DESCRIPTION
Thank you for your work on this API Wrapper!

In `Trifolium.Config.token/0` the config key expected is `:token` but the docs show to use `:trefle_token` 

https://github.com/rafaeelaudibert/trifolium/blob/889c354885118cbd564cce4527a9b2334ad55aae/lib/trifolium/config.ex#L9-L14
